### PR TITLE
refactor: can change openfeedback project id at runtime.

### DIFF
--- a/openfeedback-m2/src/main/java/io/openfeedback/android/m2/OpenFeedbackLayout.kt
+++ b/openfeedback-m2/src/main/java/io/openfeedback/android/m2/OpenFeedbackLayout.kt
@@ -16,6 +16,9 @@ import io.openfeedback.android.viewmodels.OpenFeedbackViewModel
 import io.openfeedback.android.viewmodels.models.UISessionFeedback
 import io.openfeedback.android.viewmodels.models.UIVoteItem
 
+@Deprecated(
+    message = "Use OpenFeedback component with projectId parameter."
+)
 @Composable
 fun OpenFeedback(
     openFeedbackState: OpenFeedbackConfig,
@@ -23,9 +26,31 @@ fun OpenFeedback(
     language: String,
     modifier: Modifier = Modifier,
     loading: @Composable () -> Unit = { Loading(modifier = modifier) }
+) = OpenFeedback(
+    config = openFeedbackState,
+    projectId = openFeedbackState.openFeedbackProjectId,
+    sessionId = sessionId,
+    language = language,
+    modifier = modifier,
+    loading = loading
+)
+
+@Composable
+fun OpenFeedback(
+    config: OpenFeedbackConfig,
+    projectId: String,
+    sessionId: String,
+    language: String,
+    modifier: Modifier = Modifier,
+    loading: @Composable () -> Unit = { Loading(modifier = modifier) }
 ) {
     val viewModel: OpenFeedbackViewModel = viewModel(
-        factory = OpenFeedbackViewModel.Factory.create(openFeedbackState, sessionId, language)
+        factory = OpenFeedbackViewModel.Factory.create(
+            openFeedbackConfig = config,
+            projectId = projectId,
+            sessionId = sessionId,
+            language = language
+        )
     )
     val uiState = viewModel.uiState.collectAsState()
     when (uiState.value) {

--- a/openfeedback-m3/src/main/kotlin/io/openfeedback/android/m3/OpenFeedbackLayout.kt
+++ b/openfeedback-m3/src/main/kotlin/io/openfeedback/android/m3/OpenFeedbackLayout.kt
@@ -17,6 +17,9 @@ import io.openfeedback.android.viewmodels.OpenFeedbackViewModel
 import io.openfeedback.android.viewmodels.models.UISessionFeedback
 import io.openfeedback.android.viewmodels.models.UIVoteItem
 
+@Deprecated(
+    message = "Use OpenFeedback component with projectId parameter."
+)
 @Composable
 fun OpenFeedback(
     openFeedbackState: OpenFeedbackConfig,
@@ -24,9 +27,31 @@ fun OpenFeedback(
     language: String,
     modifier: Modifier = Modifier,
     loading: @Composable () -> Unit = { Loading(modifier = modifier) }
+) = OpenFeedback(
+    config = openFeedbackState,
+    projectId = openFeedbackState.openFeedbackProjectId,
+    sessionId = sessionId,
+    language = language,
+    modifier = modifier,
+    loading = loading
+)
+
+@Composable
+fun OpenFeedback(
+    config: OpenFeedbackConfig,
+    projectId: String,
+    sessionId: String,
+    language: String,
+    modifier: Modifier = Modifier,
+    loading: @Composable () -> Unit = { Loading(modifier = modifier) }
 ) {
     val viewModel: OpenFeedbackViewModel = viewModel(
-        factory = OpenFeedbackViewModel.Factory.create(openFeedbackState, sessionId, language)
+        factory = OpenFeedbackViewModel.Factory.create(
+            openFeedbackConfig = config,
+            projectId = projectId,
+            sessionId = sessionId,
+            language = language
+        )
     )
     val uiState = viewModel.uiState.collectAsState()
     when (uiState.value) {

--- a/openfeedback-viewmodel/src/main/java/io/openfeedback/android/viewmodels/OpenFeedbackUIExtensions.kt
+++ b/openfeedback-viewmodel/src/main/java/io/openfeedback/android/viewmodels/OpenFeedbackUIExtensions.kt
@@ -4,9 +4,10 @@ import io.openfeedback.android.OpenFeedbackConfig
 import io.openfeedback.android.viewmodels.models.UISessionFeedback
 import kotlinx.coroutines.flow.combine
 
-/**
- * A bunch of extensions to get UI models from a openFeedback object
- */
+@Deprecated(
+    message = "Use getUISessionFeedback(projectId: String, sessionId: String, language: String) instead of this one.",
+    replaceWith = ReplaceWith("getUISessionFeedback(openFeedbackProjectId, sessionId, language)")
+)
 internal suspend fun OpenFeedbackConfig.getUISessionFeedback(
     sessionId: String,
     language: String
@@ -14,6 +15,24 @@ internal suspend fun OpenFeedbackConfig.getUISessionFeedback(
     getProject(),
     getUserVotes(sessionId),
     getTotalVotes(sessionId)
+) { project, userVotes, totalVotes ->
+    return@combine UISessionFeedbackWithColors(
+        OpenFeedbackModelHelper.toUISessionFeedback(project, userVotes, totalVotes, language),
+        project.chipColors
+    )
+}
+
+/**
+ * A bunch of extensions to get UI models from a openFeedback object
+ */
+internal suspend fun OpenFeedbackConfig.getUISessionFeedback(
+    projectId: String,
+    sessionId: String,
+    language: String
+) = combine(
+    getProject(projectId),
+    getUserVotes(projectId, sessionId),
+    getTotalVotes(projectId, sessionId)
 ) { project, userVotes, totalVotes ->
     return@combine UISessionFeedbackWithColors(
         OpenFeedbackModelHelper.toUISessionFeedback(project, userVotes, totalVotes, language),

--- a/sample-app/src/main/java/io/openfeedback/android/sample/MainActivity.kt
+++ b/sample-app/src/main/java/io/openfeedback/android/sample/MainActivity.kt
@@ -32,9 +32,9 @@ class MainActivity : AppCompatActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val projectId = "mMHR63ARZQpPidFQISyc"
         val config = OpenFeedbackConfig(
             context = this,
-            openFeedbackProjectId = "mMHR63ARZQpPidFQISyc",
             firebaseConfig = OpenFeedbackConfig.FirebaseConfig(
                 projectId = "openfeedback-b7ab9",
                 applicationId = "1:765209934800:android:a6bb09f3deabc2277297d5",
@@ -60,7 +60,8 @@ class MainActivity : AppCompatActivity() {
                     when (designSystem) {
                         DesignSystem.M2 -> Scaffold {
                             OpenFeedback(
-                                openFeedbackState = config,
+                                config = config,
+                                projectId = projectId,
                                 sessionId = "173222",
                                 language = "en",
                                 modifier = Modifier
@@ -70,7 +71,8 @@ class MainActivity : AppCompatActivity() {
                         }
                         DesignSystem.M3 -> androidx.compose.material3.Scaffold {
                             io.openfeedback.android.m3.OpenFeedback(
-                                openFeedbackState = config,
+                                config = config,
+                                projectId = projectId,
                                 sessionId = "173222",
                                 language = "en",
                                 modifier = Modifier


### PR DESCRIPTION
For Conferences4Hall, I support multiple events in one app but I can't change openfeedback project id easily at runtime.
With this contribution, I remove the project id from config class to pass it in Compose components.