### PR TITLE
Fix preview with OpenFeedbackFirebaseConfig object and remove orientation in OpenFeedback component

### DIFF
--- a/openfeedback-m2/src/main/java/io/openfeedback/android/m2/OpenFeedbackLayout.kt
+++ b/openfeedback-m2/src/main/java/io/openfeedback/android/m2/OpenFeedbackLayout.kt
@@ -28,7 +28,7 @@ fun OpenFeedback(
     val systemConfig = LocalConfiguration.current
     val viewModel: OpenFeedbackViewModel = viewModel(
         factory = OpenFeedbackViewModel.Factory.create(
-            firebaseApp = config.firebaseApp,
+            firebaseApp = config.firebaseApp.value,
             projectId = projectId,
             sessionId = sessionId,
             locale = systemConfig.locale

--- a/openfeedback-m3/src/main/kotlin/io/openfeedback/android/m3/OpenFeedbackLayout.kt
+++ b/openfeedback-m3/src/main/kotlin/io/openfeedback/android/m3/OpenFeedbackLayout.kt
@@ -38,7 +38,7 @@ fun OpenFeedback(
     val systemConfig = LocalConfiguration.current
     val viewModel: OpenFeedbackViewModel = viewModel(
         factory = OpenFeedbackViewModel.Factory.create(
-            firebaseApp = config.firebaseApp,
+            firebaseApp = config.firebaseApp.value,
             projectId = projectId,
             sessionId = sessionId,
             locale = systemConfig.locale

--- a/openfeedback-m3/src/main/kotlin/io/openfeedback/android/m3/OpenFeedbackLayout.kt
+++ b/openfeedback-m3/src/main/kotlin/io/openfeedback/android/m3/OpenFeedbackLayout.kt
@@ -1,6 +1,5 @@
 package io.openfeedback.android.m3
 
-import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -33,6 +32,7 @@ fun OpenFeedback(
     projectId: String,
     sessionId: String,
     modifier: Modifier = Modifier,
+    columnCount: Int = 2,
     loading: @Composable () -> Unit = { Loading(modifier = modifier) }
 ) {
     val systemConfig = LocalConfiguration.current
@@ -44,7 +44,6 @@ fun OpenFeedback(
             locale = systemConfig.locale
         )
     )
-    val columnCount = if (systemConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) 4 else 2
     val uiState = viewModel.uiState.collectAsState()
     when (uiState.value) {
         is OpenFeedbackUiState.Loading -> loading()

--- a/openfeedback-viewmodel/src/main/java/io/openfeedback/android/viewmodels/OpenFeedbackFirebaseConfig.kt
+++ b/openfeedback-viewmodel/src/main/java/io/openfeedback/android/viewmodels/OpenFeedbackFirebaseConfig.kt
@@ -12,5 +12,5 @@ data class OpenFeedbackFirebaseConfig(
     val databaseUrl: String,
     val appName: String = "openfeedback"
 ) {
-    val firebaseApp = FirebaseFactory.create(context, this, appName)
+    val firebaseApp = lazy { FirebaseFactory.create(context, this, appName) }
 }


### PR DESCRIPTION
* Evaluate `FirebaseApp` instance when it is necessary only. We can't evaluate yet `OpenFeedback` component inside a preview but we can't create an instance of  `OpenFeedbackFirebaseConfig` too. 
* Handle orientation in `OpenFeedback` component is too much opinionated. If we would like to display the OpenFeedback form in landscape but with 2 screens side by side, we probably want to keep 2 cards and not 6.