### PR TITLE
Fix automatic Sonatype release

### DIFF
--- a/build-logic/src/main/kotlin/io/openfeedback/extensions/ProjectExt.kt
+++ b/build-logic/src/main/kotlin/io/openfeedback/extensions/ProjectExt.kt
@@ -63,7 +63,7 @@ private val nexusStagingClient by lazy {
 
 internal fun Project.getOssStagingRepoId(): String? = lock.withLock {
     return try {
-        this.extensions.extraProperties["ossStagingRepositoryId"] as String?
+        this.rootProject.extensions.extraProperties["ossStagingRepositoryId"] as String?
     } catch (ignored: ExtraPropertiesExtension.UnknownPropertyException) {
         null
     }
@@ -81,7 +81,7 @@ private fun Project.getOrCreateOssStagingRepoId(): String = lock.withLock {
             description = "io.openfeedback ${rootProject.version}"
         )
     }
-    this.extensions.extraProperties["ossStagingRepositoryId"] = repoId
+    this.rootProject.extensions.extraProperties["ossStagingRepositoryId"] = repoId
 
     return repoId
 }

--- a/build-logic/src/main/kotlin/io/openfeedback/extensions/RepositoryHandlerExt.kt
+++ b/build-logic/src/main/kotlin/io/openfeedback/extensions/RepositoryHandlerExt.kt
@@ -16,7 +16,7 @@ fun RepositoryHandler.mavenSonatypeSnapshot(project: Project) = maven {
 fun RepositoryHandler.mavenSonatypeStaging(project: Project) = maven {
     name = "ossStaging"
     setUrl {
-        project.uri(project.rootProject.getOssStagingUrl())
+        project.uri(project.getOssStagingUrl())
     }
     credentials {
         username = System.getenv(EnvVarKeys.Nexus.username)


### PR DESCRIPTION
The repoId is stored in the rootProject, not the project