### PR TITLE
add `initializeOpenFeedback`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
     }
 }
 
-version = "0.2.2"
+version = "0.2.3"
 allprojects {
     repositories {
         mavenCentral()

--- a/openfeedback-m3/src/commonMain/kotlin/io/openfeedback/m3/OpenFeedbackLayout.kt
+++ b/openfeedback-m3/src/commonMain/kotlin/io/openfeedback/m3/OpenFeedbackLayout.kt
@@ -151,7 +151,7 @@ fun OpenFeedbackLayout(
 
 private val appCache = mutableMapOf<String, FirebaseApp>()
 
-fun OpenFeedbackInitialize(
+fun initializeOpenFeedback(
     config: OpenFeedbackFirebaseConfig
 ) {
     require (!appCache.containsKey(config.appName)) {

--- a/openfeedback-m3/src/commonMain/kotlin/io/openfeedback/m3/OpenFeedbackLayout.kt
+++ b/openfeedback-m3/src/commonMain/kotlin/io/openfeedback/m3/OpenFeedbackLayout.kt
@@ -19,6 +19,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.vanniktech.locale.Locale
 import com.vanniktech.locale.Locales
+import dev.gitlive.firebase.Firebase
+import dev.gitlive.firebase.FirebaseApp
+import dev.gitlive.firebase.initialize
 import dev.icerock.moko.mvvm.compose.getViewModel
 import dev.icerock.moko.mvvm.compose.viewModelFactory
 import io.openfeedback.viewmodels.OpenFeedbackFirebaseConfig
@@ -27,24 +30,26 @@ import io.openfeedback.viewmodels.OpenFeedbackViewModel
 import io.openfeedback.viewmodels.models.UIComment
 import io.openfeedback.viewmodels.models.UISessionFeedback
 import io.openfeedback.viewmodels.models.UIVoteItem
-import io.openfeedback.viewmodels.toFirebaseApp
 
+/**
+ * @param config the
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OpenFeedback(
-    config: OpenFeedbackFirebaseConfig,
     projectId: String,
     sessionId: String,
     modifier: Modifier = Modifier,
     columnCount: Int = 2,
     locale: Locale = Locale.from(Locales.currentLocaleString()),
+    appName: String? = null,
     loading: @Composable () -> Unit = { Loading(modifier = modifier) }
 ) {
     val viewModel: OpenFeedbackViewModel = getViewModel(
         key = sessionId,
         factory = viewModelFactory {
             OpenFeedbackViewModel(
-                firebaseApp = config.toFirebaseApp(),
+                firebaseApp = getApp(appName),
                 projectId = projectId,
                 sessionId = sessionId,
                 locale = locale
@@ -90,6 +95,18 @@ fun OpenFeedback(
     }
 }
 
+fun getApp(appName: String?): FirebaseApp {
+    if (appName != null) {
+        return appCache.get(appName) ?: error("OpenFeedback was not initialized for app '$appName'")
+    }
+
+    return when {
+        appCache.isEmpty() -> error("You need to call OpenFeedbackInitialize() before OpenFeedback()")
+        appCache.size == 1 -> appCache.values.single()
+        else -> error("Multiple OpenFeedback apps initialized, pass 'appName'")
+    }
+}
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun OpenFeedbackLayout(
@@ -129,5 +146,31 @@ fun OpenFeedbackLayout(
         ) {
             PoweredBy()
         }
+    }
+}
+
+private val appCache = mutableMapOf<String, FirebaseApp>()
+
+fun OpenFeedbackInitialize(
+    config: OpenFeedbackFirebaseConfig
+) {
+    require (!appCache.containsKey(config.appName)) {
+        "Openfeedback '${config.apiKey}' is already initialized"
+    }
+
+    with(config) {
+        appCache.put(
+            appName,
+            Firebase.initialize(
+                context = context,
+                options = dev.gitlive.firebase.FirebaseOptions(
+                    projectId = projectId,
+                    applicationId = applicationId,
+                    apiKey = apiKey,
+                    databaseUrl = databaseUrl
+                ),
+                name = appName
+            )
+        )
     }
 }

--- a/openfeedback-viewmodel/src/commonMain/kotlin/io/openfeedback/viewmodels/OpenFeedbackFirebaseConfig.kt
+++ b/openfeedback-viewmodel/src/commonMain/kotlin/io/openfeedback/viewmodels/OpenFeedbackFirebaseConfig.kt
@@ -40,19 +40,3 @@ data class OpenFeedbackFirebaseConfig(
     }
 }
 
-private val appCache = mutableMapOf<OpenFeedbackFirebaseConfig, FirebaseApp>()
-
-fun OpenFeedbackFirebaseConfig.toFirebaseApp(): FirebaseApp {
-    return appCache.getOrPut(this) {
-        Firebase.initialize(
-            context = context,
-            options = dev.gitlive.firebase.FirebaseOptions(
-                projectId = projectId,
-                applicationId = applicationId,
-                apiKey = apiKey,
-                databaseUrl = databaseUrl
-            ),
-            name = appName
-        )
-    }
-}

--- a/sample-app-android/src/main/java/io/openfeedback/android/MainApplication.kt
+++ b/sample-app-android/src/main/java/io/openfeedback/android/MainApplication.kt
@@ -2,6 +2,8 @@ package io.openfeedback.android
 
 import android.app.Application
 import android.content.Context
+import io.openfeedback.m3.OpenFeedbackInitialize
+import io.openfeedback.viewmodels.OpenFeedbackFirebaseConfig
 
 class MainApplication: Application() {
     lateinit var context: Context
@@ -9,5 +11,6 @@ class MainApplication: Application() {
     override fun onCreate() {
         super.onCreate()
         context = this
+        OpenFeedbackInitialize(OpenFeedbackFirebaseConfig.default(this))
     }
 }

--- a/sample-app-android/src/main/java/io/openfeedback/android/MainApplication.kt
+++ b/sample-app-android/src/main/java/io/openfeedback/android/MainApplication.kt
@@ -2,7 +2,7 @@ package io.openfeedback.android
 
 import android.app.Application
 import android.content.Context
-import io.openfeedback.m3.OpenFeedbackInitialize
+import io.openfeedback.m3.initializeOpenFeedback
 import io.openfeedback.viewmodels.OpenFeedbackFirebaseConfig
 
 class MainApplication: Application() {
@@ -11,6 +11,6 @@ class MainApplication: Application() {
     override fun onCreate() {
         super.onCreate()
         context = this
-        OpenFeedbackInitialize(OpenFeedbackFirebaseConfig.default(this))
+        initializeOpenFeedback(OpenFeedbackFirebaseConfig.default(this))
     }
 }

--- a/sample-app-shared/src/commonMain/kotlin/io/openfeedback/shared/main.kt
+++ b/sample-app-shared/src/commonMain/kotlin/io/openfeedback/shared/main.kt
@@ -41,7 +41,6 @@ fun SampleApp(
                      * https://openfeedback.io/eaJnyMXD3oNfhrrnBYDT/
                      */
                     OpenFeedback(
-                        config = OpenFeedbackFirebaseConfig.default(context),
                         projectId = "eaJnyMXD3oNfhrrnBYDT",
                         sessionId = "100",
                         modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)


### PR DESCRIPTION
Using `context` as part of the caching key fails if the activity gets destroyed and re-created. In those cases, we get an exception when trying to re-create the firebase app:

```
Exception java.lang.IllegalStateException:
  at com.google.android.gms.common.internal.Preconditions.checkState (com.google.android.gms:play-services-basement@@18.3.0:1)
  at com.google.firebase.FirebaseApp.initializeApp (FirebaseApp.java:1)
  at dev.gitlive.firebase.FirebaseKt.initialize (firebase.kt:1)
  at io.openfeedback.viewmodels.OpenFeedbackFirebaseConfigKt.toFirebaseApp (OpenFeedbackFirebaseConfig.kt:1)
  at io.openfeedback.m3.OpenFeedbackLayoutKt$OpenFeedback$$inlined$viewModelFactory$1.createViewModel (ViewModelFactory.kt:1)
```