### PR TITLE
Releasing script is now compatible with variants and creating releasing file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,3 @@
 Thanks for contributing to openfeedback-android-sdk
 
 <more stuff to be added here :)...>
-
-## Releases
-
-Releases are made automatically from CI every time a tag is pushed. 
-
-Run `./scripts/release.main.kts` to start a new release

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,5 @@
+## Releases
+
+Releases are made automatically from CI every time a tag is pushed.
+
+Run `./scripts/release.main.kts` to start a new release

--- a/librarian.properties
+++ b/librarian.properties
@@ -7,7 +7,7 @@ kdoc.artifactId=kdoc
 sonatype.backend=S01
 
 pom.groupId=io.openfeedback
-pom.version=1.0.0-alpha.3
+pom.version=1.0.0-alpha.4-SNAPSHOT
 pom.description=openfeedback-sdk-kotlin
 pom.vcsUrl=https://github.com/paug/openfeedback-sdk-kotlin
 pom.developer=openfeedback-sdk-kotlin authors

--- a/scripts/release.main.kts
+++ b/scripts/release.main.kts
@@ -23,15 +23,15 @@ fun runCommand(vararg args: String): String {
 }
 
 fun setCurrentVersion(version: String) {
-    val gradleProperties = File("build.gradle.kts")
+    val gradleProperties = File("librarian.properties")
     val newContent = gradleProperties.readLines().map {
-        it.replace(Regex("version = .*"), "version = \"$version\"")
+        it.replace(Regex("pom.version=.*"), "pom.version=\"$version\"")
     }.joinToString(separator = "\n", postfix = "\n")
     gradleProperties.writeText(newContent)
 }
 
 fun getCurrentVersion(): String {
-    val versionLines = File("build.gradle.kts").readLines().filter { it.startsWith("version =") }
+    val versionLines = File("librarian.properties").readLines().filter { it.startsWith("pom.version=") }
 
     require(versionLines.isNotEmpty()) {
         "cannot find the version in ./gradle.properties"
@@ -41,7 +41,7 @@ fun getCurrentVersion(): String {
         "multiple versions found in ./gradle.properties"
     }
 
-    val regex = Regex("version = \"(.*)-SNAPSHOT\"")
+    val regex = Regex("pom.version=(.*)-SNAPSHOT")
     val matchResult = regex.matchEntire(versionLines.first())
 
     require(matchResult != null) {


### PR DESCRIPTION
Find here some outputs:

```bash
Current version is '1.0.0-SNAPSHOT'.
1. current: tag 1.0.0 and bump to 1.1.0-SNAPSHOT
2. variant: tag 1.0.0 and bump to 1.0.0-alpha.1-SNAPSHOT
3. patch: tag 1.0.1 and bump to 1.1.0-SNAPSHOT
4. minor: tag 1.1.0 and bump to 1.2.0-SNAPSHOT
5. major: tag 2.0.0 and bump to 2.1.0-SNAPSHOT
What do you want to do [1/2/3/4/5]?
```

```bash
Current version is '1.0.0-alpha.4-SNAPSHOT'.
1. current: tag 1.0.0-alpha.4 and bump to 1.1.0-SNAPSHOT
2. variant: tag 1.0.0-alpha.4 and bump to 1.0.0-alpha.5-SNAPSHOT
3. patch: tag 1.0.1 and bump to 1.1.0-SNAPSHOT
4. minor: tag 1.1.0 and bump to 1.2.0-SNAPSHOT
5. major: tag 2.0.0 and bump to 2.1.0-SNAPSHOT
What do you want to do [1/2/3/4/5]?
```