### PR TITLE
chore: publish to Maven Central

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Prepare static content
         run: |
           export JAVA_HOME=$JAVA_HOME_21_X64 # Remove when ubuntu-latest updates to Java 21
-          ./gradlew dokkatooGeneratePublicationHtml
+          ./gradlew dokkaGeneratePublicationHtml
           mkdir -p build/static
           cp -rf build/dokka/html build/static/kdoc
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![BuildStatus](https://github.com/paug/openfeedback-android-sdk/actions/workflows/ci.yaml/badge.svg)](https://github.com/paug/openfeedback-android-sdk/actions/workflows/publish-snapshot.yaml/badge.svg)
+![BuildStatus](https://github.com/paug/openfeedback-android-sdk/actions/workflows/publish-snapshot.yaml/badge.svg)
 
 # Open-Feedback Kotlin SDK
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    `embedded-kotlin`
+    alias(libs.plugins.kgp)
+    alias(libs.plugins.tapmoc)
 }
 
 group = "build-logic"
@@ -8,11 +9,14 @@ repositories {
     mavenCentral()
     google()
     gradlePluginPortal()
+    maven("https://storage.googleapis.com/gradleup/m2")
+//    mavenLocal()
 }
 
 dependencies {
     implementation(gradleApi())
     implementation(libs.librarian)
+    implementation(libs.tapmoc)
     implementation(libs.jetbrains.kotlinx.coroutines)
     implementation(libs.android.gradle.plugin)
     implementation(libs.jetbrains.kotlin.gradle.plugin)

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,6 +1,21 @@
 rootProject.name = "build-logic"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
+pluginManagement {
+    listOf(
+        repositories,
+        dependencyResolutionManagement.repositories,
+    ).forEach {
+        it.apply {
+            mavenCentral()
+            google()
+            maven("https://storage.googleapis.com/gradleup/m2")
+            gradlePluginPortal()
+//            mavenLocal()
+        }
+    }
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {

--- a/build-logic/src/main/kotlin/accessors.kt
+++ b/build-logic/src/main/kotlin/accessors.kt
@@ -4,11 +4,11 @@ import org.jetbrains.compose.ComposePlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 
-inline fun <reified T> Project.extensionOrNull(): T? {
+inline fun <reified T: Any> Project.extensionOrNull(): T? {
     return extensions.findByType(T::class.java)
 }
 
-inline fun <reified T> Project.extension(): T {
+inline fun <reified T: Any> Project.extension(): T {
     return extensionOrNull<T>() ?: error("No extension of type '${T::class.java.name}")
 }
 

--- a/build-logic/src/main/kotlin/main.kt
+++ b/build-logic/src/main/kotlin/main.kt
@@ -1,17 +1,15 @@
 import com.android.build.api.dsl.CommonExtension
 import com.gradleup.librarian.gradle.Librarian
 import com.gradleup.librarian.gradle.configureAndroidCompatibility
-import compat.patrouille.configureJavaCompatibility
-import compat.patrouille.configureKotlinCompatibility
 import org.gradle.api.Project
+import org.gradle.api.attributes.Attribute
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+import tapmoc.configureJavaCompatibility
+import tapmoc.configureKotlinCompatibility
 
 private fun Project.configureAndroid(namespace: String) {
     configureAndroidCompatibility(23, 35, 35)
-
-    configureJavaCompatibility(17)
-    configureKotlinCompatibility("2.0.0")
 
     extensions.getByType(CommonExtension::class.java).apply {
         this.namespace = namespace
@@ -69,6 +67,8 @@ fun Project.library(
 fun Project.androidApp(
     namespace: String,
 ) {
+    configureJavaCompatibility(17)
+    configureKotlinCompatibility("2.0.0")
     configureAndroid(namespace = namespace)
     configureKotlin(composeMetrics = true)
 }

--- a/build-logic/src/main/kotlin/main.kt
+++ b/build-logic/src/main/kotlin/main.kt
@@ -1,8 +1,8 @@
 import com.android.build.api.dsl.CommonExtension
 import com.gradleup.librarian.gradle.Librarian
 import com.gradleup.librarian.gradle.configureAndroidCompatibility
-import com.gradleup.librarian.gradle.configureJavaCompatibility
-import com.gradleup.librarian.gradle.configureKotlinCompatibility
+import compat.patrouille.configureJavaCompatibility
+import compat.patrouille.configureKotlinCompatibility
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
@@ -11,7 +11,6 @@ private fun Project.configureAndroid(namespace: String) {
     configureAndroidCompatibility(23, 35, 35)
 
     configureJavaCompatibility(17)
-    //configureKotlinCompatibility(librarianProperties().kotlinCompatibility() ?: error("no kotlin compatibility found"))
     configureKotlinCompatibility("2.0.0")
 
     extensions.getByType(CommonExtension::class.java).apply {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,9 @@ buildscript {
     repositories {
         mavenCentral()
         google()
+        maven("https://storage.googleapis.com/gradleup/m2")
         gradlePluginPortal()
+//        mavenLocal()
     }
     dependencies {
         //noinspection UseTomlInstead

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ jetbrains-kotlinx-serialization = "1.8.0"
 lyricist = "1.7.0"
 multiplatform-locale = "0.9.0"
 touchlab-kermit = "2.0.5"
+tapmoc = "0.4.1-SNAPSHOT-3afff1879a8a81afafb99c51d73b3b3d22d11a3c"
 
 [libraries]
 android-gradle-plugin = "com.android.tools.build:gradle:8.9.0"
@@ -41,8 +42,13 @@ jetbrains-kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotl
 jetbrains-kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "jetbrains-kotlin-coroutines" }
 jetbrains-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "jetbrains-kotlinx-datetime" }
 jetbrains-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "jetbrains-kotlinx-serialization" }
-librarian = "com.gradleup.librarian:librarian-gradle-plugin:0.2.1"
+librarian = "com.gradleup.librarian:librarian-gradle-plugin:0.2.2-SNAPSHOT-4d88675e4846e5141d9a2cbaa0dc5ec292315dce"
+tapmoc = { module =  "com.gradleup.tapmoc:com.gradleup.tapmoc.gradle.plugin", version.ref = "tapmoc" }
 lyricist = { module = "cafe.adriel.lyricist:lyricist", version.ref = "lyricist" }
 touchlab-kermit = { module = "co.touchlab:kermit", version.ref = "touchlab-kermit" }
 vanniktech-multiplatform-locale = { module = "com.vanniktech:multiplatform-locale", version.ref = "multiplatform-locale" }
 version-catalog-update = "nl.littlerobots.version-catalog-update:nl.littlerobots.version-catalog-update.gradle.plugin:0.8.5"
+
+[plugins]
+kgp = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrains-kotlin" }
+tapmoc = { id = "com.gradleup.tapmoc", version.ref = "tapmoc" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ jetbrains-kotlinx-collections-immutable = { module = "org.jetbrains.kotlinx:kotl
 jetbrains-kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "jetbrains-kotlin-coroutines" }
 jetbrains-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "jetbrains-kotlinx-datetime" }
 jetbrains-kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "jetbrains-kotlinx-serialization" }
-librarian = "com.gradleup.librarian:librarian-gradle-plugin:0.0.7"
+librarian = "com.gradleup.librarian:librarian-gradle-plugin:0.2.1"
 lyricist = { module = "cafe.adriel.lyricist:lyricist", version.ref = "lyricist" }
 touchlab-kermit = { module = "co.touchlab:kermit", version.ref = "touchlab-kermit" }
 vanniktech-multiplatform-locale = { module = "com.vanniktech:multiplatform-locale", version.ref = "multiplatform-locale" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/librarian.root.properties
+++ b/librarian.root.properties
@@ -4,9 +4,9 @@ kotlin.compatibility=2.0.0
 kdoc.olderVersions=
 kdoc.artifactId=kdoc
 
-pom.groupId=io.github.4rthurrousseau
-pom.version=1.0.0-alpha.6-SNAPSHOT
+pom.groupId=io.openfeedback
+pom.version=1.0.0-alpha.5-SNAPSHOT
 pom.description=openfeedback-sdk-kotlin
-pom.vcsUrl=https://github.com/4rthurrousseau/openfeedback-sdk-kotlin
+pom.vcsUrl=https://github.com/paug/openfeedback-sdk-kotlin
 pom.developer=openfeedback-sdk-kotlin authors
 pom.license=MIT License

--- a/librarian.root.properties
+++ b/librarian.root.properties
@@ -4,12 +4,9 @@ kotlin.compatibility=2.0.0
 kdoc.olderVersions=
 kdoc.artifactId=kdoc
 
-sonatype.backend=S01
-sonatype.release=Manual
-
-pom.groupId=io.openfeedback
-pom.version=1.0.0-alpha.5-SNAPSHOT
+pom.groupId=io.github.4rthurrousseau
+pom.version=1.0.0-alpha.6-SNAPSHOT
 pom.description=openfeedback-sdk-kotlin
-pom.vcsUrl=https://github.com/paug/openfeedback-sdk-kotlin
+pom.vcsUrl=https://github.com/4rthurrousseau/openfeedback-sdk-kotlin
 pom.developer=openfeedback-sdk-kotlin authors
 pom.license=MIT License

--- a/librarian.root.properties
+++ b/librarian.root.properties
@@ -2,6 +2,7 @@ java.compatibility=17
 kotlin.compatibility=2.0.0
 
 kdoc.olderVersions=
+kdoc.projects=:openfeedback,:openfeedback-m3,:openfeedback-resources,:openfeedback-ui-models,:openfeedback-viewmodel
 kdoc.artifactId=kdoc
 
 pom.groupId=io.openfeedback
@@ -10,3 +11,6 @@ pom.description=openfeedback-sdk-kotlin
 pom.vcsUrl=https://github.com/paug/openfeedback-sdk-kotlin
 pom.developer=openfeedback-sdk-kotlin authors
 pom.license=MIT License
+
+# https://github.com/GradleUp/tapmoc/issues/82
+checkDependenciesCompatibility=false

--- a/sample-app-android/build.gradle.kts
+++ b/sample-app-android/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.compose")
     id("org.jetbrains.kotlin.plugin.compose")
-    id("org.jetbrains.dokka")
 }
 
 androidApp("io.openfeedback.android")

--- a/sample-app-android/build.gradle.kts
+++ b/sample-app-android/build.gradle.kts
@@ -1,10 +1,9 @@
-import com.gradleup.librarian.gradle.configureAndroidCompatibility
-
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.compose")
     id("org.jetbrains.kotlin.plugin.compose")
+    id("org.jetbrains.dokka")
 }
 
 androidApp("io.openfeedback.android")

--- a/sample-app-shared/build.gradle.kts
+++ b/sample-app-shared/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
     id("com.android.library")
-    id("org.jetbrains.dokka")
 }
 
 library(

--- a/sample-app-shared/build.gradle.kts
+++ b/sample-app-shared/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
     id("com.android.library")
+    id("org.jetbrains.dokka")
 }
 
 library(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,11 +1,16 @@
 rootProject.name = "openfeedback-sdk-kotlin"
 
 pluginManagement {
-    listOf(repositories, dependencyResolutionManagement.repositories).forEach {
+    listOf(
+        repositories,
+        dependencyResolutionManagement.repositories,
+    ).forEach {
         it.apply {
             mavenCentral()
             google()
+            maven("https://storage.googleapis.com/gradleup/m2")
             gradlePluginPortal()
+//            mavenLocal()
         }
     }
 }


### PR DESCRIPTION
This PR sets up the project for publication to Maven Central using the Librarian library (fixes #47).

I upgraded Librarian from 0.0.7 to 0.2.1 to use the latest publication API and target Maven Central (see GradleUp/librarian#55).

Following the upgrade, I had to change the Gradle task used to build Dokka documentation as Librarian switched from Dokkatoo to Dokka its 0.2.0 version (GradleUp/librarian#97).

Both `LIBRARIAN_SONATYPE_USERNAME` and `LIBRARIAN_SONATYPE_PASSWORD` secrets will probably need to be updated.

**Important note :**
I had to add the Dokka plugin to both `sample-app-android` and `sample-app-shared` due to it being applied inside the Librarian plugin. The build fails without it, **but in the current state, the `sample-app-shared` and `sample-app-android` documentation are published with the library documentation**.

I feel like it should not be necessary regarding the comment in the `librarianModule` [extension method](https://github.com/GradleUp/librarian/blob/51318fc735e5cfc561c7cb41bb22c1d7647d0fdb/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/module.kt#L184) :
```
/**
* Only configure Dokka for projects that are published.
* This is because we don't want those in the aggregate KDoc output.
*/
```

I wonder if this has something to do with the `Librarian.root` method that [seems to configure the Dokka aggregate](https://github.com/GradleUp/librarian/blob/51318fc735e5cfc561c7cb41bb22c1d7647d0fdb/librarian-gradle-plugin/src/main/kotlin/com/gradleup/librarian/gradle/dokka.kt#L107) using `allprojects` (without checking whether publication is enabled or not).

I'm not confident with the Librarian library, so let me know if I'm mistaken @martinbonnin ! 🙂 